### PR TITLE
Keep mac address accross scale up and down when use static IP

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -144,7 +144,7 @@ func (vm *AutoScalerServerNode) launchVM(c types.ClientGenerator, nodeLabels, sy
 
 		err = fmt.Errorf(constantes.ErrVMAlreadyCreated, vm.NodeName)
 
-	} else if _, err = vsphere.Create(vm.NodeName, userInfo.GetUserName(), userInfo.GetAuthKeys(), vm.serverConfig.CloudInit, network, "", vm.Memory, vm.CPU, vm.Disk); err != nil {
+	} else if _, err = vsphere.Create(vm.NodeName, userInfo.GetUserName(), userInfo.GetAuthKeys(), vm.serverConfig.CloudInit, network, "", vm.Memory, vm.CPU, vm.Disk, vm.NodeIndex); err != nil {
 
 		err = fmt.Errorf(constantes.ErrUnableToLaunchVM, vm.NodeName, err)
 

--- a/vsphere/configuration.go
+++ b/vsphere/configuration.go
@@ -120,7 +120,7 @@ func (conf *Configuration) GetClient(ctx *context.Context) (*Client, error) {
 
 // CreateWithContext will create a named VM not powered
 // memory and disk are in megabytes
-func (conf *Configuration) CreateWithContext(ctx *context.Context, name string, userName, authKey string, cloudInit interface{}, network *Network, annotation string, memory int, cpus int, disk int) (*VirtualMachine, error) {
+func (conf *Configuration) CreateWithContext(ctx *context.Context, name string, userName, authKey string, cloudInit interface{}, network *Network, annotation string, memory, cpus, disk, nodeIndex int) (*VirtualMachine, error) {
 	var err error
 	var client *Client
 	var dc *Datacenter
@@ -130,8 +130,8 @@ func (conf *Configuration) CreateWithContext(ctx *context.Context, name string, 
 	if client, err = conf.GetClient(ctx); err == nil {
 		if dc, err = client.GetDatacenter(ctx, conf.DataCenter); err == nil {
 			if ds, err = dc.GetDatastore(ctx, conf.DataStore); err == nil {
-				if vm, err = ds.CreateVirtualMachine(ctx, name, conf.TemplateName, conf.VMBasePath, conf.Resource, conf.Template, conf.LinkedClone, network, conf.Customization); err == nil {
-					err = vm.Configure(ctx, userName, authKey, cloudInit, network, annotation, memory, cpus, disk)
+				if vm, err = ds.CreateVirtualMachine(ctx, name, conf.TemplateName, conf.VMBasePath, conf.Resource, conf.Template, conf.LinkedClone, network, conf.Customization, nodeIndex); err == nil {
+					err = vm.Configure(ctx, userName, authKey, cloudInit, network, annotation, memory, cpus, disk, nodeIndex)
 				}
 			}
 		}
@@ -147,11 +147,11 @@ func (conf *Configuration) CreateWithContext(ctx *context.Context, name string, 
 
 // Create will create a named VM not powered
 // memory and disk are in megabytes
-func (conf *Configuration) Create(name string, userName, authKey string, cloudInit interface{}, network *Network, annotation string, memory int, cpus int, disk int) (*VirtualMachine, error) {
+func (conf *Configuration) Create(name string, userName, authKey string, cloudInit interface{}, network *Network, annotation string, memory, cpus, disk, nodeIndex int) (*VirtualMachine, error) {
 	ctx := context.NewContext(conf.Timeout)
 	defer ctx.Cancel()
 
-	return conf.CreateWithContext(ctx, name, userName, authKey, cloudInit, network, annotation, memory, cpus, disk)
+	return conf.CreateWithContext(ctx, name, userName, authKey, cloudInit, network, annotation, memory, cpus, disk, nodeIndex)
 }
 
 // DeleteWithContext a VM by name

--- a/vsphere/datastore.go
+++ b/vsphere/datastore.go
@@ -198,8 +198,8 @@ func (ds *Datastore) CreateVirtualMachine(ctx *context.Context, name, templateNa
 
 				if network != nil {
 					if devices, err := templateVM.Device(ctx); err == nil {
-						for netIndex, inf := range network.Interfaces {
-							if inf.NeedToReconfigure(nodeIndex << netIndex) {
+						for _, inf := range network.Interfaces {
+							if inf.NeedToReconfigure(nodeIndex) {
 								// In case we dont find the preconfigured net card, we add it
 								inf.Existing = false
 
@@ -211,7 +211,7 @@ func (ds *Datastore) CreateVirtualMachine(ctx *context.Context, name, templateNa
 										if match, err := inf.MatchInterface(ctx, ds.Datacenter, ethernet.GetVirtualEthernetCard()); match && err == nil {
 
 											// Change the mac address
-											if inf.ChangeAddress(ethernet.GetVirtualEthernetCard(), nodeIndex<<netIndex) {
+											if inf.ChangeAddress(ethernet.GetVirtualEthernetCard(), nodeIndex) {
 												configSpecs = append(configSpecs, &types.VirtualDeviceConfigSpec{
 													Operation: types.VirtualDeviceConfigSpecOperationEdit,
 													Device:    device,

--- a/vsphere/vsphere_test.go
+++ b/vsphere/vsphere_test.go
@@ -141,7 +141,7 @@ func Test_createVM(t *testing.T) {
 	if testFeature("Test_createVM") {
 		config := loadFromJson(confName)
 
-		_, err := config.Create(config.New.Name, config.SSH.GetUserName(), config.SSH.GetAuthKeys(), config.CloudInit, config.New.Network, config.New.Annotation, config.New.Memory, config.New.CPUS, config.New.Disk)
+		_, err := config.Create(config.New.Name, config.SSH.GetUserName(), config.SSH.GetAuthKeys(), config.CloudInit, config.New.Network, config.New.Annotation, config.New.Memory, config.New.CPUS, config.New.Disk, 0)
 
 		if assert.NoError(t, err, "Can't create VM") {
 			t.Logf("VM created")


### PR DESCRIPTION
During instense stress of scale up / down, the same static IP have different mac address and the AARP table is not correctly updated.

`
time="2021-09-20T18:00:00Z" level=error msg="Unable to launch VM:vmware-ca-k8s-vm-107 for nodegroup: vmware-ca-k8s. Reason: unable to join the master kubernetes node for VM: vmware-ca-k8s-vm-107, reason: failed to dial: dial tcp 192.168.1.127:22: connect: connection refused"
`

The consequence is the vsphere autoscaler is not able to iniate a SSH connection with nodes. 

This PR propose to recycle the same macaddress for the same IP for the same node index