### PR TITLE
Limit the number of parallel VM creation during scaleup

### DIFF
--- a/constantes/errors.go
+++ b/constantes/errors.go
@@ -82,6 +82,9 @@ const (
 	// ErrUnableToLaunchVM error msg
 	ErrUnableToLaunchVM = "unable to launch the VM owned by node: %s, reason: %v"
 
+	// ErrUnableToLaunchVMNodeGroupNotReady error msg
+	ErrUnableToLaunchVMNodeGroupNotReady = "unable to launch the VM owned by node: %s, reason: launch group is not ready"
+
 	// ErrUnableToDeleteVM error msg
 	ErrUnableToDeleteVM = "unable to delete the VM owned by node: %s, reason: %v"
 

--- a/constantes/errors.go
+++ b/constantes/errors.go
@@ -41,7 +41,7 @@ const (
 	ErrUnableToCreateNodeGroup = "can't create node group: %s, reason: %v"
 
 	// ErrUnableToLaunchNodeGroupNotCreated error msg
-	ErrUnableToLaunchNodeGroupNotCreated = "Unable to launch group: %s, reason: node group is not created"
+	ErrUnableToLaunchNodeGroupNotCreated = "unable to launch group: %s, reason: node group is not created"
 
 	// ErrUnableToLaunchNodeGroup error msg
 	ErrUnableToLaunchNodeGroup = "unable to launch group: %s, fail to launch some VMs"

--- a/masterkube/bin/create-masterkube.sh
+++ b/masterkube/bin/create-masterkube.sh
@@ -511,6 +511,7 @@ AUTOSCALER_CONFIG=$(cat <<EOF
     "secret": "${SCHEME}",
     "minNode": ${MINNODES},
     "maxNode": ${MAXNODES},
+    "maxNode-per-cycle": 2,
     "nodePrice": 0.0,
     "podPrice": 0.0,
     "image": "${TARGET_IMAGE}",

--- a/server/node.go
+++ b/server/node.go
@@ -400,3 +400,7 @@ func (vm *AutoScalerServerNode) GetVSphere() *vsphere.Configuration {
 func (vm *AutoScalerServerNode) setServerConfiguration(config *types.AutoScalerServerConfig) {
 	vm.serverConfig = config
 }
+
+func (vm *AutoScalerServerNode) retrieveNetworkInfos() error {
+	return vm.VSphereConfig.RetrieveNetworkInfos(vm.NodeName, vm.NodeIndex)
+}

--- a/server/node.go
+++ b/server/node.go
@@ -398,6 +398,7 @@ func (vm *AutoScalerServerNode) GetVSphere() *vsphere.Configuration {
 }
 
 func (vm *AutoScalerServerNode) setServerConfiguration(config *types.AutoScalerServerConfig) {
+	vm.VSphereConfig.Network.UpdateMacAddressTable(vm.NodeIndex)
 	vm.serverConfig = config
 }
 

--- a/server/nodegroup.go
+++ b/server/nodegroup.go
@@ -367,6 +367,8 @@ func (g *AutoScalerServerNodeGroup) autoDiscoveryNodes(client types.ClientGenera
 						if err != nil {
 							glog.Errorf(constantes.ErrLabelNodeReturnError, nodeInfo.Name, err)
 						}
+					} else {
+						node.retrieveNetworkInfos()
 					}
 
 					g.Nodes[nodeID] = node

--- a/server/nodegroup.go
+++ b/server/nodegroup.go
@@ -420,9 +420,9 @@ func (g *AutoScalerServerNodeGroup) autoDiscoveryNodes(client types.ClientGenera
 						if err != nil {
 							glog.Errorf(constantes.ErrLabelNodeReturnError, nodeInfo.Name, err)
 						}
-					} else {
-						node.retrieveNetworkInfos()
 					}
+
+					node.retrieveNetworkInfos()
 
 					g.Nodes[nodeID] = node
 					g.RunningNode[lastNodeIndex] = ServerNodeStateRunning

--- a/server/nodegroup.go
+++ b/server/nodegroup.go
@@ -396,7 +396,7 @@ func (g *AutoScalerServerNodeGroup) autoDiscoveryNodes(client types.ClientGenera
 							NodeIndex:        lastNodeIndex,
 							State:            AutoScalerServerNodeStateRunning,
 							AutoProvisionned: nodeInfo.Annotations[constantes.AnnotationNodeAutoProvisionned] == "true",
-							VSphereConfig:    g.configuration.GetVSphereConfiguration(g.NodeGroupIdentifier),
+							VSphereConfig:    g.configuration.GetVSphereConfiguration(g.NodeGroupIdentifier).Copy(),
 							Addresses: []string{
 								runningIP,
 							},

--- a/types/types.go
+++ b/types/types.go
@@ -136,21 +136,22 @@ func (ssh *AutoScalerServerSSH) GetAuthKeys() string {
 
 // AutoScalerServerConfig is contains configuration
 type AutoScalerServerConfig struct {
-	Network            string                            `default:"tcp" json:"network"`         // Mandatory, Network to listen (see grpc doc) to listen
-	Listen             string                            `default:"0.0.0.0:5200" json:"listen"` // Mandatory, Address to listen
-	ProviderID         string                            `json:"secret"`                        // Mandatory, secret Identifier, client must match this
-	MinNode            int                               `json:"minNode"`                       // Mandatory, Min AutoScaler VM
-	MaxNode            int                               `json:"maxNode"`                       // Mandatory, Max AutoScaler VM
-	NodePrice          float64                           `json:"nodePrice"`                     // Optional, The VM price
-	PodPrice           float64                           `json:"podPrice"`                      // Optional, The pod price
-	KubeAdm            KubeJoinConfig                    `json:"kubeadm"`
-	DefaultMachineType string                            `default:"{\"standard\": {}}" json:"default-machine"`
-	Machines           map[string]*MachineCharacteristic `default:"{\"standard\": {}}" json:"machines"` // Mandatory, Available machines
-	CloudInit          interface{}                       `json:"cloud-init"`                            // Optional, The cloud init conf file
-	Optionals          *AutoScalerServerOptionals        `json:"optionals"`
-	ResourceLimiter    *ResourceLimiter                  `json:"limits"`
-	SSH                *AutoScalerServerSSH              `json:"ssh-infos"`
-	VMwareInfos        map[string]*vsphere.Configuration `json:"vmware"`
+	Network                string                            `default:"tcp" json:"network"`         // Mandatory, Network to listen (see grpc doc) to listen
+	Listen                 string                            `default:"0.0.0.0:5200" json:"listen"` // Mandatory, Address to listen
+	ProviderID             string                            `json:"secret"`                        // Mandatory, secret Identifier, client must match this
+	MinNode                int                               `json:"minNode"`                       // Mandatory, Min AutoScaler VM
+	MaxNode                int                               `json:"maxNode"`                       // Mandatory, Max AutoScaler VM
+	MaxCreatedNodePerCycle int                               `json:"maxNode-per-cycle" default:"2"`
+	NodePrice              float64                           `json:"nodePrice"` // Optional, The VM price
+	PodPrice               float64                           `json:"podPrice"`  // Optional, The pod price
+	KubeAdm                KubeJoinConfig                    `json:"kubeadm"`
+	DefaultMachineType     string                            `default:"{\"standard\": {}}" json:"default-machine"`
+	Machines               map[string]*MachineCharacteristic `default:"{\"standard\": {}}" json:"machines"` // Mandatory, Available machines
+	CloudInit              interface{}                       `json:"cloud-init"`                            // Optional, The cloud init conf file
+	Optionals              *AutoScalerServerOptionals        `json:"optionals"`
+	ResourceLimiter        *ResourceLimiter                  `json:"limits"`
+	SSH                    *AutoScalerServerSSH              `json:"ssh-infos"`
+	VMwareInfos            map[string]*vsphere.Configuration `json:"vmware"`
 }
 
 // GetVSphereConfiguration returns the vsphere named conf or default

--- a/vsphere/configuration.go
+++ b/vsphere/configuration.go
@@ -390,8 +390,6 @@ func (conf *Configuration) RetrieveNetworkInfosWithContext(ctx *context.Context,
 		return err
 	}
 
-	conf.Network.UpdateMacAddressTable(nodeIndex)
-
 	return vm.collectNetworkInfos(ctx, conf.Network, nodeIndex)
 }
 

--- a/vsphere/configuration.go
+++ b/vsphere/configuration.go
@@ -73,14 +73,18 @@ func (conf *Configuration) getURL() (string, error) {
 	return u.String(), err
 }
 
-// Clone duplicate the conf, change ip address in network config if needed
-func (conf *Configuration) Clone(nodeIndex int) (*Configuration, error) {
-
+// Create a shadow copy
+func (conf *Configuration) Copy() *Configuration {
 	var dup Configuration
 
-	if err := Copy(&dup, conf); err != nil {
-		return nil, err
-	}
+	Copy(&dup, conf)
+
+	return &dup
+}
+
+// Clone duplicate the conf, change ip address in network config if needed
+func (conf *Configuration) Clone(nodeIndex int) (*Configuration, error) {
+	dup := conf.Copy()
 
 	if dup.Network != nil {
 		for _, inf := range dup.Network.Interfaces {
@@ -94,7 +98,7 @@ func (conf *Configuration) Clone(nodeIndex int) (*Configuration, error) {
 		}
 	}
 
-	return &dup, nil
+	return dup, nil
 }
 
 // GetClient create a new govomi client

--- a/vsphere/configuration.go
+++ b/vsphere/configuration.go
@@ -382,3 +382,22 @@ func (conf *Configuration) Status(name string) (*Status, error) {
 
 	return conf.StatusWithContext(ctx, name)
 }
+
+func (conf *Configuration) RetrieveNetworkInfosWithContext(ctx *context.Context, name string, nodeIndex int) error {
+	vm, err := conf.VirtualMachineWithContext(ctx, name)
+
+	if err != nil {
+		return err
+	}
+
+	conf.Network.UpdateMacAddressTable(nodeIndex)
+
+	return vm.collectNetworkInfos(ctx, conf.Network, nodeIndex)
+}
+
+func (conf *Configuration) RetrieveNetworkInfos(name string, nodeIndex int) error {
+	ctx := context.NewContext(conf.Timeout)
+	defer ctx.Cancel()
+
+	return conf.RetrieveNetworkInfosWithContext(ctx, name, nodeIndex)
+}

--- a/vsphere/vm.go
+++ b/vsphere/vm.go
@@ -181,6 +181,29 @@ func (vm *VirtualMachine) VimClient() *vim25.Client {
 	return vm.Datastore.VimClient()
 }
 
+func (vm *VirtualMachine) collectNetworkInfos(ctx *context.Context, network *Network, nodeIndex int) error {
+	virtualMachine := vm.VirtualMachine(ctx)
+	devices, err := virtualMachine.Device(ctx)
+
+	if err == nil {
+		for _, device := range devices {
+			// It's an ether device?
+			if ethernet, ok := device.(types.BaseVirtualEthernetCard); ok {
+				// Match my network?
+				for _, inf := range network.Interfaces {
+					card := ethernet.GetVirtualEthernetCard()
+					if match, err := inf.MatchInterface(ctx, vm.Datastore.Datacenter, card); match && err == nil {
+						inf.AttachMacAddress(card.MacAddress, nodeIndex)
+						return nil
+					}
+				}
+			}
+		}
+	}
+
+	return err
+}
+
 func (vm *VirtualMachine) addNetwork(ctx *context.Context, network *Network, devices object.VirtualDeviceList, nodeIndex int) (object.VirtualDeviceList, error) {
 	var err error
 

--- a/vsphere/vm.go
+++ b/vsphere/vm.go
@@ -194,7 +194,6 @@ func (vm *VirtualMachine) collectNetworkInfos(ctx *context.Context, network *Net
 					card := ethernet.GetVirtualEthernetCard()
 					if match, err := inf.MatchInterface(ctx, vm.Datastore.Datacenter, card); match && err == nil {
 						inf.AttachMacAddress(card.MacAddress, nodeIndex)
-						return nil
 					}
 				}
 			}


### PR DESCRIPTION
When the number of scale up nodes is to high, the clone VM process goes slow down due limited disk IO.
The goal is to reduce the number of created VM in parallel, the default is 2 and no limit if the field **maxNode-per-cycle** in the config file is less than 1

```json
AUTOSCALER_CONFIG=$(cat <<EOF
{
    "network": "${TRANSPORT}",
    "listen": "${LISTEN}",
    "secret": "${SCHEME}",
    "minNode": ${MINNODES},
    "maxNode": ${MAXNODES},
    "maxNode-per-cycle": 2,
    "nodePrice": 0.0,
    "podPrice": 0.0,
    "image": "${TARGET_IMAGE}",
....
```

- Include a fix: Rebuild the allocated mac addresses table when the process restart. 