### PR TITLE
Include all existing nodes

### DIFF
--- a/server/nodegroup.go
+++ b/server/nodegroup.go
@@ -368,8 +368,10 @@ func (g *AutoScalerServerNodeGroup) autoDiscoveryNodes(client types.ClientGenera
 		if len(providerID) > 0 {
 			out, _ = utils.NodeGroupIDFromProviderID(g.ServiceIdentifier, providerID)
 
-			// Ignore nodes not handled by autoscaler
-			if out == g.NodeGroupIdentifier && nodeInfo.Annotations[constantes.AnnotationNodeAutoProvisionned] == "true" {
+			autoProvisionned, _ := strconv.ParseBool(nodeInfo.Annotations[constantes.AnnotationNodeAutoProvisionned])
+
+			// Ignore nodes not handled by autoscaler if option includeExistingNode == false
+			if out == g.NodeGroupIdentifier && (autoProvisionned || includeExistingNode) {
 				glog.Infof("Discover node:%s matching nodegroup:%s", providerID, g.NodeGroupIdentifier)
 
 				if nodeID, err = utils.NodeNameFromProviderID(g.ServiceIdentifier, providerID); err == nil {

--- a/server/nodegroup.go
+++ b/server/nodegroup.go
@@ -344,7 +344,7 @@ func (g *AutoScalerServerNodeGroup) addNodes(c types.ClientGenerator, delta int)
 	return result
 }
 
-func (g *AutoScalerServerNodeGroup) autoDiscoveryNodes(client types.ClientGenerator, scaleDownDisabled bool) error {
+func (g *AutoScalerServerNodeGroup) autoDiscoveryNodes(client types.ClientGenerator, includeExistingNode bool) error {
 	var lastNodeIndex = 0
 	var nodeInfos *apiv1.NodeList
 	var out string

--- a/server/nodegroup.go
+++ b/server/nodegroup.go
@@ -401,7 +401,7 @@ func (g *AutoScalerServerNodeGroup) autoDiscoveryNodes(client types.ClientGenera
 							NodeName:         nodeID,
 							NodeIndex:        lastNodeIndex,
 							State:            AutoScalerServerNodeStateRunning,
-							AutoProvisionned: nodeInfo.Annotations[constantes.AnnotationNodeAutoProvisionned] == "true",
+							AutoProvisionned: autoProvisionned,
 							VSphereConfig:    g.configuration.GetVSphereConfiguration(g.NodeGroupIdentifier).Copy(),
 							Addresses: []string{
 								runningIP,
@@ -410,8 +410,8 @@ func (g *AutoScalerServerNodeGroup) autoDiscoveryNodes(client types.ClientGenera
 						}
 
 						err = client.AnnoteNode(nodeInfo.Name, map[string]string{
-							constantes.AnnotationScaleDownDisabled:    strconv.FormatBool(scaleDownDisabled && !node.AutoProvisionned),
-							constantes.AnnotationNodeAutoProvisionned: strconv.FormatBool(node.AutoProvisionned),
+							constantes.AnnotationScaleDownDisabled:    strconv.FormatBool(!autoProvisionned),
+							constantes.AnnotationNodeAutoProvisionned: strconv.FormatBool(autoProvisionned),
 							constantes.AnnotationNodeIndex:            strconv.Itoa(node.NodeIndex),
 						})
 

--- a/server/server.go
+++ b/server/server.go
@@ -153,10 +153,8 @@ func (s *AutoScalerServerApp) doAutoProvision() error {
 
 				if _, err = s.newNodeGroup(nodeGroupIdentifier, nodeGroupDef.MinSize, nodeGroupDef.MaxSize, s.Configuration.DefaultMachineType, labels, systemLabels, true); err == nil {
 					if ng, err = s.createNodeGroup(nodeGroupIdentifier); err == nil {
-						if node.GetIncludeExistingNode() {
-							if err = ng.autoDiscoveryNodes(s.kubeClient, true); err == nil {
-								return err
-							}
+						if err = ng.autoDiscoveryNodes(s.kubeClient, nodeGroupDef.GetIncludeExistingNode()); err == nil {
+							return err
 						}
 					}
 				}
@@ -166,10 +164,8 @@ func (s *AutoScalerServerApp) doAutoProvision() error {
 				}
 			} else {
 				// If the nodegroup already exists, reparse nodes
-				if node.GetIncludeExistingNode() {
-					if err = ng.autoDiscoveryNodes(s.kubeClient, true); err == nil {
-						return err
-					}
+				if err = ng.autoDiscoveryNodes(s.kubeClient, nodeGroupDef.GetIncludeExistingNode()); err == nil {
+					return err
 				}
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -127,8 +127,8 @@ func (s *AutoScalerServerApp) doAutoProvision() error {
 	var ng *AutoScalerServerNodeGroup
 	var err error
 
-	for _, node := range s.NodesDefinition {
-		nodeGroupIdentifier := node.GetNodeGroupID()
+	for _, nodeGroupDef := range s.NodesDefinition {
+		nodeGroupIdentifier := nodeGroupDef.GetNodeGroupID()
 
 		if len(nodeGroupIdentifier) > 0 {
 			ng = s.Groups[nodeGroupIdentifier]
@@ -143,15 +143,15 @@ func (s *AutoScalerServerApp) doAutoProvision() error {
 				}
 
 				// Default labels
-				if node.GetLabels() != nil {
-					for k, v := range node.GetLabels() {
+				if nodeGroupDef.GetLabels() != nil {
+					for k, v := range nodeGroupDef.GetLabels() {
 						labels[k] = v
 					}
 				}
 
-				glog.Infof("Auto provision for nodegroup:%s, minSize:%d, maxSize:%d", nodeGroupIdentifier, node.MinSize, node.MaxSize)
+				glog.Infof("Auto provision for nodegroup:%s, minSize:%d, maxSize:%d", nodeGroupIdentifier, nodeGroupDef.MinSize, nodeGroupDef.MaxSize)
 
-				if _, err = s.newNodeGroup(nodeGroupIdentifier, node.MinSize, node.MaxSize, s.Configuration.DefaultMachineType, labels, systemLabels, true); err == nil {
+				if _, err = s.newNodeGroup(nodeGroupIdentifier, nodeGroupDef.MinSize, nodeGroupDef.MaxSize, s.Configuration.DefaultMachineType, labels, systemLabels, true); err == nil {
 					if ng, err = s.createNodeGroup(nodeGroupIdentifier); err == nil {
 						if node.GetIncludeExistingNode() {
 							if err = ng.autoDiscoveryNodes(s.kubeClient, true); err == nil {


### PR DESCRIPTION
Fix issue #14 

control plane nodes and worker nodes are not included in node group when it was required.

Consequence: the limit (cpu/ram) doesn't include control plande and worker nodes