### PR TITLE
FIX: Don't recopy etcd for rke2 control-plane and remove credentials provider

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -107,7 +107,7 @@ func (vm *AutoScalerServerNode) waitReady(c types.ClientGenerator) error {
 func (vm *AutoScalerServerNode) recopyEtcdSslFilesIfNeeded() error {
 	var err error
 
-	if *vm.serverConfig.Distribution != types.RKE2DistributionName && (vm.ControlPlaneNode || *vm.serverConfig.UseExternalEtdc) {
+	if (vm.serverConfig.Distribution == nil || *vm.serverConfig.Distribution != types.RKE2DistributionName) && (vm.ControlPlaneNode || *vm.serverConfig.UseExternalEtdc) {
 		glog.Infof("Recopy etcd certs for node:%s for nodegroup: %s", vm.NodeName, vm.NodeGroupID)
 
 		if err = utils.Scp(vm.serverConfig.SSH, vm.IPAddress, vm.serverConfig.ExtSourceEtcdSslDir, "."); err != nil {
@@ -127,7 +127,7 @@ func (vm *AutoScalerServerNode) recopyEtcdSslFilesIfNeeded() error {
 func (vm *AutoScalerServerNode) recopyKubernetesPKIIfNeeded() error {
 	var err error
 
-	if *vm.serverConfig.Distribution != types.RKE2DistributionName && vm.ControlPlaneNode {
+	if (vm.serverConfig.Distribution == nil || *vm.serverConfig.Distribution != types.RKE2DistributionName) && vm.ControlPlaneNode {
 		glog.Infof("Recopy pki kubernetes certs for node:%s for nodegroup: %s", vm.NodeName, vm.NodeGroupID)
 
 		if err = utils.Scp(vm.serverConfig.SSH, vm.IPAddress, vm.serverConfig.KubernetesPKISourceDir, "."); err != nil {

--- a/server/node.go
+++ b/server/node.go
@@ -107,7 +107,7 @@ func (vm *AutoScalerServerNode) waitReady(c types.ClientGenerator) error {
 func (vm *AutoScalerServerNode) recopyEtcdSslFilesIfNeeded() error {
 	var err error
 
-	if vm.ControlPlaneNode || *vm.serverConfig.UseExternalEtdc {
+	if *vm.serverConfig.Distribution != types.RKE2DistributionName && (vm.ControlPlaneNode || *vm.serverConfig.UseExternalEtdc) {
 		glog.Infof("Recopy etcd certs for node:%s for nodegroup: %s", vm.NodeName, vm.NodeGroupID)
 
 		if err = utils.Scp(vm.serverConfig.SSH, vm.IPAddress, vm.serverConfig.ExtSourceEtcdSslDir, "."); err != nil {
@@ -127,7 +127,7 @@ func (vm *AutoScalerServerNode) recopyEtcdSslFilesIfNeeded() error {
 func (vm *AutoScalerServerNode) recopyKubernetesPKIIfNeeded() error {
 	var err error
 
-	if vm.ControlPlaneNode {
+	if *vm.serverConfig.Distribution != types.RKE2DistributionName && vm.ControlPlaneNode {
 		glog.Infof("Recopy pki kubernetes certs for node:%s for nodegroup: %s", vm.NodeName, vm.NodeGroupID)
 
 		if err = utils.Scp(vm.serverConfig.SSH, vm.IPAddress, vm.serverConfig.KubernetesPKISourceDir, "."); err != nil {
@@ -303,13 +303,6 @@ func (vm *AutoScalerServerNode) rke2AgentJoin(c types.ClientGenerator) error {
 			"rke2-ingress-nginx",
 			"rke2-metrics-server",
 		}
-
-		if vm.serverConfig.UseExternalEtdc != nil && *vm.serverConfig.UseExternalEtdc {
-			config["datastore-endpoint"] = rke2.DatastoreEndpoint
-			config["datastore-cafile"] = fmt.Sprintf("%s/ca.pem", vm.serverConfig.ExtDestinationEtcdSslDir)
-			config["datastore-certfile"] = fmt.Sprintf("%s/etcd.pem", vm.serverConfig.ExtDestinationEtcdSslDir)
-			config["datastore-keyfile"] = fmt.Sprintf("%s/etcd-key.pem", vm.serverConfig.ExtDestinationEtcdSslDir)
-		}
 	}
 
 	// Append extras arguments
@@ -342,11 +335,16 @@ func (vm *AutoScalerServerNode) rke2AgentJoin(c types.ClientGenerator) error {
 			if err = utils.Scp(vm.serverConfig.SSH, vm.IPAddress, f.Name(), tmpConfigDestinationFile); err != nil {
 				result = fmt.Errorf("unable to transfer file: %s to %s, reason: %v", f.Name(), tmpConfigDestinationFile, err)
 			} else {
-				args := []string{
+				args := make([]string, 0, 5)
+
+				if rke2.DeleteCredentialsProvider {
+					args = append(args, "rm -rf /var/lib/rancher/credentialprovider")
+				}
+
+				args = append(args,
 					fmt.Sprintf("cp %s %s", tmpConfigDestinationFile, dstFile),
 					fmt.Sprintf("systemctl enable %s.service", service),
-					fmt.Sprintf("systemctl start %s.service", service),
-				}
+					fmt.Sprintf("systemctl start %s.service", service))
 
 				result = vm.executeCommands(args, false, c)
 			}
@@ -379,6 +377,10 @@ func (vm *AutoScalerServerNode) k3sAgentJoin(c types.ClientGenerator) error {
 		args = append(args, k3s.ExtraCommands...)
 	}
 
+	if k3s.DeleteCredentialsProvider {
+		args = append(args, "rm -rf /var/lib/rancher/credentialprovider")
+	}
+
 	args = append(args, "systemctl enable k3s.service", "systemctl start k3s.service")
 
 	return vm.executeCommands(args, false, c)
@@ -386,11 +388,11 @@ func (vm *AutoScalerServerNode) k3sAgentJoin(c types.ClientGenerator) error {
 
 func (vm *AutoScalerServerNode) joinCluster(c types.ClientGenerator) error {
 	if vm.serverConfig.Distribution != nil {
-		if *vm.serverConfig.Distribution == "k3s" {
+		if *vm.serverConfig.Distribution == types.K3SDistributionName {
 			return vm.k3sAgentJoin(c)
-		} else if *vm.serverConfig.Distribution == "rke2" {
+		} else if *vm.serverConfig.Distribution == types.RKE2DistributionName {
 			return vm.rke2AgentJoin(c)
-		} else if *vm.serverConfig.Distribution == "external" {
+		} else if *vm.serverConfig.Distribution == types.ExternalDistributionName {
 			return vm.externalAgentJoin(c)
 		}
 	}

--- a/server/nodegroup.go
+++ b/server/nodegroup.go
@@ -315,7 +315,7 @@ func (g *AutoScalerServerNodeGroup) addManagedNode(crd *v1alpha1.ManagedNode) (*
 
 		annoteMaster := ""
 
-		if g.configuration.Distribution != nil && *g.configuration.Distribution != "kubeadm" {
+		if g.configuration.Distribution != nil && *g.configuration.Distribution != types.KubeAdmDistributionName {
 			annoteMaster = "true"
 		}
 
@@ -342,7 +342,7 @@ func (g *AutoScalerServerNodeGroup) prepareNodes(c types.ClientGenerator, delta 
 	config := g.configuration.GetVSphereConfiguration(g.NodeGroupIdentifier)
 	annoteMaster := ""
 
-	if g.configuration.Distribution != nil && *g.configuration.Distribution != "kubeadm" {
+	if g.configuration.Distribution != nil && *g.configuration.Distribution != types.KubeAdmDistributionName {
 		annoteMaster = "true"
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -1648,26 +1648,26 @@ func StartServer(kubeClient types.ClientGenerator, c *types.Config) {
 
 	if config.Distribution == nil {
 		if c.UseK3S {
-			c.Distribution = "k3s"
+			c.Distribution = types.K3SDistributionName
 		}
 
 		config.Distribution = &c.Distribution
 	}
 
 	switch *config.Distribution {
-	case "kubeadm":
+	case types.KubeAdmDistributionName:
 		if config.KubeAdm == nil {
 			glog.Fatal("KubeAdm configuration is not defined")
 		}
-	case "k3s":
+	case types.K3SDistributionName:
 		if config.K3S == nil {
 			glog.Fatal("K3S configuration is not defined")
 		}
-	case "rke2":
+	case types.RKE2DistributionName:
 		if config.RKE2 == nil {
 			glog.Fatal("RKE2 configuration is not defined")
 		}
-	case "external":
+	case types.ExternalDistributionName:
 		if config.External == nil {
 			glog.Fatal("External configuration is not defined")
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -35,6 +35,13 @@ const (
 	ManagedNodeMaxDiskSize = 1024 * 1024
 )
 
+const (
+	RKE2DistributionName     = "rke2"
+	K3SDistributionName      = "k3s"
+	KubeAdmDistributionName  = "kubeadm"
+	ExternalDistributionName = "external"
+)
+
 // KubernetesLabel labels
 type KubernetesLabel map[string]string
 
@@ -145,11 +152,19 @@ type KubeJoinConfig struct {
 	ExtraArguments []string `json:"extras-args,omitempty"`
 }
 
-type RancherJoinConfig struct {
-	Address           string   `json:"address,omitempty"`
-	Token             string   `json:"token,omitempty"`
-	ExtraCommands     []string `json:"extras-commands,omitempty"`
-	DatastoreEndpoint string   `json:"datastore-endpoint,omitempty"`
+type K3SJoinConfig struct {
+	Address                   string   `json:"address,omitempty"`
+	Token                     string   `json:"token,omitempty"`
+	ExtraCommands             []string `json:"extras-commands,omitempty"`
+	DatastoreEndpoint         string   `json:"datastore-endpoint,omitempty"`
+	DeleteCredentialsProvider bool     `json:"delete-credentials-provider,omitempty"`
+}
+
+type RKE2JoinConfig struct {
+	Address                   string   `json:"address,omitempty"`
+	Token                     string   `json:"token,omitempty"`
+	ExtraCommands             []string `json:"extras-commands,omitempty"`
+	DeleteCredentialsProvider bool     `json:"delete-credentials-provider,omitempty"`
 }
 
 type ExternalJoinConfig struct {
@@ -254,8 +269,8 @@ type AutoScalerServerConfig struct {
 	NodePrice                  float64                           `json:"nodePrice"`                                 // Optional, The VM price
 	PodPrice                   float64                           `json:"podPrice"`                                  // Optional, The pod price
 	KubeAdm                    *KubeJoinConfig                   `json:"kubeadm"`
-	K3S                        *RancherJoinConfig                `json:"k3s,omitempty"`
-	RKE2                       *RancherJoinConfig                `json:"rke2,omitempty"`
+	K3S                        *K3SJoinConfig                    `json:"k3s,omitempty"`
+	RKE2                       *RKE2JoinConfig                   `json:"rke2,omitempty"`
 	External                   *ExternalJoinConfig               `json:"external,omitempty"`
 	DefaultMachineType         string                            `default:"standard" json:"default-machine"`
 	NodeLabels                 KubernetesLabel                   `json:"nodeLabels"`
@@ -375,7 +390,7 @@ func NewConfig() *Config {
 	return &Config{
 		APIServerURL:             "",
 		KubeConfig:               "",
-		Distribution:             "kubeadm",
+		Distribution:             KubeAdmDistributionName,
 		UseExternalEtdc:          false,
 		UseVanillaGrpcProvider:   false,
 		UseControllerManager:     true,
@@ -426,7 +441,7 @@ func (cfg *Config) ParseFlags(args []string, version string) error {
 	app.Flag("debug", "Debug mode").Default("false").BoolVar(&cfg.DebugMode)
 
 	app.Flag("use-k3s", "Tell we use k3s in place of kubeadm (deprecated, use distribution flag)").Default("false").BoolVar(&cfg.UseK3S)
-	app.Flag("distribution", "Which kubernetes distribution to use: kubeadm, k3s, rke2, external").Default("kubeadm").EnumVar(&cfg.Distribution, "kubeadm", "k3s", "rke2", "external")
+	app.Flag("distribution", "Which kubernetes distribution to use: kubeadm, k3s, rke2, external").Default(K3SDistributionName).EnumVar(&cfg.Distribution, KubeAdmDistributionName, K3SDistributionName, RKE2DistributionName, ExternalDistributionName)
 	app.Flag("use-vanilla-grpc", "Tell we use vanilla autoscaler externalgrpc cloudprovider").Default("false").BoolVar(&cfg.UseVanillaGrpcProvider)
 	app.Flag("use-controller-manager", "Tell we use vsphere controller manager").Default("true").BoolVar(&cfg.UseControllerManager)
 


### PR DESCRIPTION
RKE2 doesn't support external etcd, the controller try to recopy etcd files when it launch a control plane.
RKE2 & K3S 1.28.4 use a removed feature gate for credentials provider config